### PR TITLE
Add -p option to mkdir command for prevent file exists error

### DIFF
--- a/create_desktop_file.sh
+++ b/create_desktop_file.sh
@@ -19,4 +19,4 @@ EOS
 chmod +x Notion.desktop
 ## This can be updated if this path is not valid. 
 ## cp -p Notion.desktop ~/.local/share/applications
-[ ! -d "$~/.local/share/applications" ] && { cd ~/.local/share; mkdir applications; cd ${WORKING_DIR}; cp -p Notion.desktop ~/.local/share/applications; } || { cd ${WORKING_DIR}; cp -p Notion.desktop ~/.local/share/applications; }
+[ ! -d "$~/.local/share/applications" ] && { cd ~/.local/share; mkdir -p applications; cd ${WORKING_DIR}; cp -p Notion.desktop ~/.local/share/applications; } || { cd ${WORKING_DIR}; cp -p Notion.desktop ~/.local/share/applications; }


### PR DESCRIPTION
```
$ ./create_desktop_file.sh
mkdir: cannot create directory ‘applications’: File exists
```

Failed to create `~/.local/share/applications` directory if already exists